### PR TITLE
fix for \r in error messages from tracker

### DIFF
--- a/ngx_http_mogilefs_module.c
+++ b/ngx_http_mogilefs_module.c
@@ -51,7 +51,7 @@ typedef struct ngx_http_mogilefs_loc_conf_s {
     ngx_http_upstream_conf_t   upstream;
     ngx_array_t                *tracker_lengths;
     ngx_array_t                *tracker_values;
-    ngx_str_t                  domain;
+    ngx_http_complex_value_t   *domain_complex;
     ngx_array_t                *class_templates;
     ngx_str_t                  fetch_location;
     ngx_flag_t                 noverify;
@@ -130,6 +130,8 @@ static ngx_int_t ngx_http_mogilefs_add_variables(ngx_conf_t *cf);
 static char *
 ngx_http_mogilefs_tracker_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *
+ngx_http_mogilefs_complex_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *
 ngx_http_mogilefs_class_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *
 ngx_http_mogilefs_pass_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
@@ -182,9 +184,9 @@ static ngx_command_t  ngx_http_mogilefs_commands[] = {
 
     { ngx_string("mogilefs_domain"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_str_slot,
+      ngx_http_mogilefs_complex_command,
       NGX_HTTP_LOC_CONF_OFFSET,
-      offsetof(ngx_http_mogilefs_loc_conf_t, domain),
+      offsetof(ngx_http_mogilefs_loc_conf_t, domain_complex),
       NULL },
 
     { ngx_string("mogilefs_connect_timeout"),
@@ -777,13 +779,10 @@ ngx_http_mogilefs_create_request(ngx_http_request_t *r)
         return NGX_HTTP_BAD_REQUEST;
     }
 
-    if(mgcf->parent != NULL) {
-        domain.len = mgcf->parent->domain.len;
-        domain.data = mgcf->parent->domain.data;
-    }
-    else {
-        domain.len = mgcf->domain.len;
-        domain.data = mgcf->domain.data;
+    rc = ngx_http_complex_value(r, mgcf->parent != NULL ? mgcf->parent->domain_complex : mgcf->domain_complex, &domain);
+
+    if(rc == NGX_ERROR) {
+        return rc;
     }
 
     rc = ngx_http_mogilefs_eval_class(r, mgcf->parent != NULL ? mgcf->parent : mgcf);
@@ -1358,7 +1357,9 @@ ngx_http_mogilefs_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->upstream.upstream = prev->upstream.upstream;
     }
 
-    ngx_conf_merge_str_value(conf->domain, prev->domain, "default");
+    if (conf->domain_complex == NULL) {
+        conf->domain_complex = prev->domain_complex;
+    }
 
     ngx_conf_merge_value(conf->noverify, prev->noverify, 0);
 
@@ -1465,6 +1466,46 @@ ngx_http_mogilefs_tracker_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf
 
     mgcf->upstream.upstream = ngx_http_upstream_add(cf, &u, 0);
     if (mgcf->upstream.upstream == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+/* 
+ * Copied from: nginx-1.0.0/src/http/ngx_http_script.c
+ * ngx_http_set_complex_value_slot() 
+ */
+static char *
+ngx_http_mogilefs_complex_command(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    char  *p = conf;
+
+    ngx_str_t                          *value;
+    ngx_http_complex_value_t          **cv;
+    ngx_http_compile_complex_value_t    ccv;
+
+    cv = (ngx_http_complex_value_t **) (p + cmd->offset);
+
+    if (*cv != NULL) {
+        return "duplicate";
+    }
+
+    *cv = ngx_palloc(cf->pool, sizeof(ngx_http_complex_value_t));
+    if (*cv == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = *cv;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 
@@ -1648,6 +1689,10 @@ ngx_http_mogilefs_pass_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (pmgcf->upstream.upstream == 0 && pmgcf->tracker_lengths == NULL) {
         return "no tracker defined";
+    }
+
+    if (pmgcf->domain_complex == NULL) {
+        return "no domain defined";
     }
 
     for(i=0;i < NGX_MOGILEFS_MAX_PATHS;i++) {

--- a/ngx_http_mogilefs_module.c
+++ b/ngx_http_mogilefs_module.c
@@ -1067,6 +1067,7 @@ ngx_http_mogilefs_process_error_response(ngx_http_request_t *r,
 
     line->data += sizeof("ERR ") - 1;
     line->len -= sizeof("ERR ") - 1;
+	line->len -= 1; /* strip \r */
 
     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                   "mogilefs error: \"%V\"", line);


### PR DESCRIPTION
hi,

just made a small fix to make \r disappear from tracker error messages in the nginx log. 

Thats how it was before :
mogilefs error: "unknown_key unknown_key^M" while reading response header from upstream

now:
mogilefs error: "unknown_key unknown_key" while reading response header from upstream
